### PR TITLE
Make defaultSettings inheritable

### DIFF
--- a/src/Lean/SlimServiceProvider.php
+++ b/src/Lean/SlimServiceProvider.php
@@ -54,7 +54,7 @@ class SlimServiceProvider extends AbstractServiceProvider
     /**
      * @var array
      */
-    private $defaultSettings = [
+    protected $defaultSettings = [
         'httpVersion' => '1.1',
         'responseChunkSize' => 4096,
         'outputBuffering' => 'append',


### PR DESCRIPTION
Allows to extend from this service provider and change only 1 setting without manually copying them all over.

E.g.: something like this
```php
$this->container->share('settings', function() {
    return array_merge($this->defaultSettings, [
        'displayErrorDetails' => true,
    ]);
});
```